### PR TITLE
Fix errors swift concurrency checking completed

### DIFF
--- a/AssetsPickerViewController.podspec
+++ b/AssetsPickerViewController.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'AssetsPickerViewController'
-  s.version          = '2.9.7'
+  s.version          = '3.0.0'
   s.summary          = 'Picker controller that supports multiple photos and videos written in Swift.'
 
 # This description is used to generate tags and improve search results.
@@ -29,7 +29,7 @@ Fully customizable UI.
   s.source           = { :git => 'https://github.com/DragonCherry/AssetsPickerViewController.git', :tag => s.version.to_s }
   s.social_media_url = 'https://www.linkedin.com/in/jeongyong'
 
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = '13.0'
 
   s.source_files = 'AssetsPickerViewController/Classes/**/*'
   
@@ -40,5 +40,6 @@ Fully customizable UI.
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
   # s.frameworks = 'UIKit', 'MapKit'
-  s.dependency 'SnapKit'
+  s.dependency 'SnapKit', '~> 5.0.1'
+  s.pod_target_xcconfig = { 'SWIFT_STRICT_CONCURRENCY' => 'complete' }
 end

--- a/AssetsPickerViewController/Classes/Assets/AssetsManager.swift
+++ b/AssetsPickerViewController/Classes/Assets/AssetsManager.swift
@@ -496,13 +496,12 @@ extension AssetsManager {
             if authorizationStatus != newStatus {
                 let oldStatus = authorizationStatus
                 authorizationStatus = newStatus
-
-              let authorizationworkItem = DispatchWorkItem {
-                for subscriber in self.subscribers {
-                    subscriber.assetsManager(manager: self, authorizationStatusChanged: oldStatus, newStatus: newStatus)
+                let authorizationworkItem = DispatchWorkItem {
+                  for subscriber in self.subscribers {
+                      subscriber.assetsManager(manager: self, authorizationStatusChanged: oldStatus, newStatus: newStatus)
+                  }
                 }
-              }
-              DispatchQueue.main.async(execute: authorizationworkItem)
+                DispatchQueue.main.async(execute: authorizationworkItem)
             }
         }
         
@@ -621,11 +620,11 @@ extension AssetsManager {
     }
 
 
-  /// Fetches and calls the `completion` closure with the data of all the albums from the five `types`.
-  /// It also updates the`fetchMap` and `albumMap` objects.
-  /// - Parameters:
-  ///   - types: list of asset collection type.
-  ///   - completion: closure to return an `AssetsAlbumArrayEntry` object with the data.
+    /// Fetches and calls the `completion` closure with the data of all the albums from the five `types`.
+    /// It also updates the`fetchMap` and `albumMap` objects.
+    /// - Parameters:
+    ///   - types: list of asset collection type.
+    ///   - completion: closure to return an `AssetsAlbumArrayEntry` object with the data.
     func fetchAllAlbums(types: [PHAssetCollectionType], completion: @escaping (AssetsAlbumArrayEntry) -> Void ) {
       Task {
         let entryResults: [AlbumsArrayAndEntry] = await withTaskGroup(of: AlbumsArrayAndEntry.self) { group in
@@ -663,7 +662,6 @@ extension AssetsManager {
         self.albumMap = albumMap
         let result = (fetchedAlbumsArray, sortedAlbumsArray, albumsFetchArray)
         completion(result)
-
       }
     }
     

--- a/AssetsPickerViewController/Classes/Assets/AssetsManager.swift
+++ b/AssetsPickerViewController/Classes/Assets/AssetsManager.swift
@@ -609,6 +609,9 @@ extension AssetsManager {
         }
     }
 
+    /// Calls `fetchAlbumsAsync` and returns all the albums entries for the give album type.
+    /// - Parameter albumType: Asset collection type.
+    /// - Returns: AlbumsArrayAndEntry ( tuple of albumsArrayEntry and fetchedEntry)
     func fetchAlbumsAndEntry(albumType: PHAssetCollectionType) async -> AlbumsArrayAndEntry {
       return await withCheckedContinuation{ continuation in
         fetchAlbumsAsync(forAlbumType: albumType, complection: { (albumsArrayEntry, fetchedEntry) in
@@ -618,8 +621,11 @@ extension AssetsManager {
     }
 
 
+  /// Fetches and calls the `completion` closure with the data of all the albums from the five `types`.
+  /// - Parameters:
+  ///   - types: <#types description#>
+  ///   - completion: <#completion description#>
     func fetchAllAlbums(types: [PHAssetCollectionType], completion: @escaping (AssetsAlbumArrayEntry) -> Void ) {
-      // TODO: add doc
       Task {
         let entryResults: [AlbumsArrayAndEntry] = await withTaskGroup(of: AlbumsArrayAndEntry.self) { group in
           var entries = [AlbumsArrayAndEntry]()

--- a/AssetsPickerViewController/Classes/Assets/AssetsManager.swift
+++ b/AssetsPickerViewController/Classes/Assets/AssetsManager.swift
@@ -622,9 +622,10 @@ extension AssetsManager {
 
 
   /// Fetches and calls the `completion` closure with the data of all the albums from the five `types`.
+  /// It also updates the`fetchMap` and `albumMap` objects.
   /// - Parameters:
-  ///   - types: <#types description#>
-  ///   - completion: <#completion description#>
+  ///   - types: list of asset collection type.
+  ///   - completion: closure to return an `AssetsAlbumArrayEntry` object with the data.
     func fetchAllAlbums(types: [PHAssetCollectionType], completion: @escaping (AssetsAlbumArrayEntry) -> Void ) {
       Task {
         let entryResults: [AlbumsArrayAndEntry] = await withTaskGroup(of: AlbumsArrayAndEntry.self) { group in

--- a/AssetsPickerViewController/Classes/Common/SwiftAlert.swift
+++ b/AssetsPickerViewController/Classes/Common/SwiftAlert.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@MainActor
 @available(iOS 8.0, *)
 @objcMembers public class SwiftAlert: NSObject {
     

--- a/AssetsPickerViewController/Classes/Photo/Controller/AssetsPreviewController.swift
+++ b/AssetsPickerViewController/Classes/Photo/Controller/AssetsPreviewController.swift
@@ -147,20 +147,13 @@ open class AssetsPreviewController: UIViewController {
     }
     
     deinit {
-// TODO: test this live
         logd("Released \(type(of: self))")
     }
 
-  open override func viewWillDisappear(_ animated: Bool) {
-    super.viewWillDisappear(animated)
-    player?.pause()
-  }
-
-  open override func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
-    player?.play()
-  }
-
+    open override func viewWillDisappear(_ animated: Bool) {
+      super.viewWillDisappear(animated)
+      player?.pause()
+    }
 }
 
 extension AssetsPreviewController {

--- a/AssetsPickerViewController/Classes/Photo/Controller/AssetsPreviewController.swift
+++ b/AssetsPickerViewController/Classes/Photo/Controller/AssetsPreviewController.swift
@@ -147,9 +147,20 @@ open class AssetsPreviewController: UIViewController {
     }
     
     deinit {
-        player?.pause()
+// TODO: test this live
         logd("Released \(type(of: self))")
     }
+
+  open override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+    player?.pause()
+  }
+
+  open override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    player?.play()
+  }
+
 }
 
 extension AssetsPreviewController {
@@ -199,9 +210,9 @@ extension AssetsPreviewController {
 
 extension AssetsPreviewController: PHLivePhotoViewDelegate {
     @available(iOS 9.1, *)
-    public func livePhotoView(_ livePhotoView: PHLivePhotoView, willBeginPlaybackWith playbackStyle: PHLivePhotoViewPlaybackStyle) {}
+    nonisolated public func livePhotoView(_ livePhotoView: PHLivePhotoView, willBeginPlaybackWith playbackStyle: PHLivePhotoViewPlaybackStyle) {}
     
     @available(iOS 9.1, *)
-    public func livePhotoView(_ livePhotoView: PHLivePhotoView, didEndPlaybackWith playbackStyle: PHLivePhotoViewPlaybackStyle) {}
+    nonisolated public func livePhotoView(_ livePhotoView: PHLivePhotoView, didEndPlaybackWith playbackStyle: PHLivePhotoViewPlaybackStyle) {}
 }
 

--- a/AssetsPickerViewController/Classes/Picker/AssetsCameraManager.swift
+++ b/AssetsPickerViewController/Classes/Picker/AssetsCameraManager.swift
@@ -10,10 +10,12 @@ import AVFoundation
 import Photos
 import UIKit
 
+@MainActor
 protocol AssetsPickerManagerDelegate: NSObject {
     func assetsPickerManagerSavedAsset(identifier: String)
 }
 
+@MainActor
 class AssetsPickerManager: NSObject {
     
     fileprivate var successCallback: ((Any?) -> Void)?

--- a/AssetsPickerViewController/Classes/Picker/AssetsPickerColors.swift
+++ b/AssetsPickerViewController/Classes/Picker/AssetsPickerColors.swift
@@ -13,7 +13,7 @@ public struct AssetsPickerColors {
   var label: UIColor
   var secondaryLabel: UIColor
   var background: UIColor
-  var cellBackground: UIColor
+  public var cellBackground: UIColor
   
   public init(
     defaultCheckmark: UIColor? = nil,

--- a/AssetsPickerViewController/Classes/Picker/AssetsPickerConfig.swift
+++ b/AssetsPickerViewController/Classes/Picker/AssetsPickerConfig.swift
@@ -71,7 +71,8 @@ open class AssetsPickerConfig : NSObject {
     open var albumLandscapeForcedCellWidth: CGFloat?
     open var albumLandscapeForcedCellHeight: CGFloat?
     open var albumLandscapeCellSize: CGSize = .zero
-    
+
+    @MainActor
     func albumItemSpace(isPortrait: Bool) -> CGFloat {
         let size = isPortrait ? UIScreen.main.portraitSize : UIScreen.main.landscapeSize
         let count = CGFloat(isPortrait ? (albumPortraitColumnCount ?? albumPortraitDefaultColumnCount) : albumLandscapeColumnCount ?? albumLandscapeDefaultColumnCount)
@@ -136,7 +137,8 @@ open class AssetsPickerConfig : NSObject {
     open var allowsEditing: Bool = true
   
     public override init() {}
-    
+
+    @MainActor
     @discardableResult
     open func prepare() -> Self {
         

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "AssetsPickerViewController",
     defaultLocalization: "en",
-    platforms: [.iOS(.v10)],
+    platforms: [.iOS(.v13)],
     products: [
         .library(
             name: "AssetsPickerViewController",
@@ -20,7 +20,8 @@ let package = Package(
             dependencies: ["SnapKit"],
             path: "AssetsPickerViewController",
             sources: ["Classes"],
-            resources: [.process("Assets")]
+            resources: [.process("Assets")],
+            swiftSettings: [.unsafeFlags(["-Xfrontend", "-warn-concurrency"])]
         )
     ],
     swiftLanguageVersions: [.v4_2, .v5]


### PR DESCRIPTION
## Purpose

The default value for the "Strict Concurrency Checking" setting is Minimal which boils down to the Compiler only checking explicit Sendable annotations amongst other things. This setting is the least restrictive and enforces as little of Swift Concurrency's constraints as possible for the time being.

With Complete you will get the full suite of concurrency constraints, essentially as they will work in Swift 6.

- Fix all errors from the project

## Approach

- Annotate the corresponding classes with `@MainActor` attribute
- Refactor `fetchAllAlbums` to use taskGroup and get all the albums data using `fetchAlbumsAndEntry`
- Move `player.pause()` from `deinit` to `viewWillDissapear`

## Screenshots

https://user-images.githubusercontent.com/2923778/222836066-71fc9f7b-4ac8-426d-a52d-21a0b223eed3.mov

https://user-images.githubusercontent.com/2923778/222836152-2b9c8f39-5686-4f17-bbdf-d0b29ea3c7d2.mov


