### PR TITLE
Fix warnings swift concurrency checking completed Part 1

### DIFF
--- a/AssetsPickerViewController/Classes/Album/Controller/AssetsAlbumViewController.swift
+++ b/AssetsPickerViewController/Classes/Album/Controller/AssetsAlbumViewController.swift
@@ -343,7 +343,7 @@ extension AssetsAlbumViewController {
 // MARK: - AssetsManagerDelegate
 extension AssetsAlbumViewController: AssetsManagerDelegate {
     
-    public func assetsManagerFetched(manager: AssetsManager) {
+    public func assetsManagerFetched() {
         collectionView.reloadData()
         let isFetchedAlbums = AssetsManager.shared.isFetchedAlbums
         if isFetchedAlbums {
@@ -355,34 +355,34 @@ extension AssetsAlbumViewController: AssetsManagerDelegate {
         }
     }
     
-    public func assetsManager(manager: AssetsManager, authorizationStatusChanged oldStatus: PHAuthorizationStatus, newStatus: PHAuthorizationStatus) {}
+    public func assetsManager(authorizationStatusChanged oldStatus: PHAuthorizationStatus, newStatus: PHAuthorizationStatus) {}
     
-    public func assetsManager(manager: AssetsManager, reloadedAlbumsInSection section: Int) {
+    public func assetsManager(reloadedAlbumsInSection section: Int) {
         logi("reloadedAlbumsInSection section: \(section)")
         collectionView.reloadSections(IndexSet(integer: section))
     }
     
-    public func assetsManager(manager: AssetsManager, insertedAlbums albums: [PHAssetCollection], at indexPaths: [IndexPath]) {
+    public func assetsManager(insertedAlbums albums: [PHAssetCollection], at indexPaths: [IndexPath]) {
         logi("insertedAlbums at indexPaths: \(indexPaths)")
         collectionView.insertItems(at: indexPaths)
     }
     
-    public func assetsManager(manager: AssetsManager, removedAlbums albums: [PHAssetCollection], at indexPaths: [IndexPath]) {
+    public func assetsManager(removedAlbums albums: [PHAssetCollection], at indexPaths: [IndexPath]) {
         logi("removedAlbums at indexPaths: \(indexPaths)")
         collectionView.deleteItems(at: indexPaths)
     }
     
-    public func assetsManager(manager: AssetsManager, updatedAlbums albums: [PHAssetCollection], at indexPaths: [IndexPath]) {
+    public func assetsManager(updatedAlbums albums: [PHAssetCollection], at indexPaths: [IndexPath]) {
         logi("updatedAlbums at indexPaths: \(indexPaths)")
         collectionView.reloadItems(at: indexPaths)
     }
     
-    public func assetsManager(manager: AssetsManager, reloadedAlbum album: PHAssetCollection, at indexPath: IndexPath) {
+    public func assetsManager(reloadedAlbum album: PHAssetCollection, at indexPath: IndexPath) {
         logi("reloadedAlbum at indexPath: \(indexPath)")
         collectionView.reloadItems(at: [indexPath])
     }
     
-    public func assetsManager(manager: AssetsManager, insertedAssets assets: [PHAsset], at indexPaths: [IndexPath]) {}
-    public func assetsManager(manager: AssetsManager, removedAssets assets: [PHAsset], at indexPaths: [IndexPath]) {}
-    public func assetsManager(manager: AssetsManager, updatedAssets assets: [PHAsset], at indexPaths: [IndexPath]) {}
+    public func assetsManager(insertedAssets assets: [PHAsset], at indexPaths: [IndexPath]) {}
+    public func assetsManager(removedAssets assets: [PHAsset], at indexPaths: [IndexPath]) {}
+    public func assetsManager(updatedAssets assets: [PHAsset], at indexPaths: [IndexPath]) {}
 }

--- a/AssetsPickerViewController/Classes/Album/View/AssetsAlbumCell.swift
+++ b/AssetsPickerViewController/Classes/Album/View/AssetsAlbumCell.swift
@@ -9,6 +9,7 @@
 import UIKit
 import Photos
 
+@MainActor
 public protocol AssetsAlbumCellProtocol {
     var album: PHAssetCollection? { get set }
     var isSelected: Bool { get set }

--- a/AssetsPickerViewController/Classes/Assets/AssetsManager.swift
+++ b/AssetsPickerViewController/Classes/Assets/AssetsManager.swift
@@ -9,8 +9,6 @@
 import UIKit
 @preconcurrency import Photos
 
-//CHE lo q hay q pensar es si este delegado tiene q estar en el main thread, creo q no porq si
-//bien es usado por los VCs no se si hay q forzarlo, quizas se use por un service?
 // MARK: - AssetsManagerDelegate
 @MainActor
 public protocol AssetsManagerDelegate: AnyObject {
@@ -493,7 +491,7 @@ extension AssetsManager {
                 }
                 return false
             }
-        } else if#available(iOS 13, *) {
+        } else if #available(iOS 13, *) {
             newStatus = PHPhotoLibrary.authorizationStatus()
             if authorizationStatus != newStatus {
               let oldStatus = authorizationStatus

--- a/AssetsPickerViewController/Classes/Common/AssetsFetchService.swift
+++ b/AssetsPickerViewController/Classes/Common/AssetsFetchService.swift
@@ -8,6 +8,7 @@
 import Photos
 
 // MARK: - Image Fetching IDs
+@MainActor
 class AssetsFetchService {
     
     var requestMap = [IndexPath: PHImageRequestID]()

--- a/AssetsPickerViewController/Classes/Photo/Controller/AssetsPhotoViewController+AssetsManager.swift
+++ b/AssetsPickerViewController/Classes/Photo/Controller/AssetsPhotoViewController+AssetsManager.swift
@@ -11,9 +11,9 @@ import Photos
 // MARK: - AssetsManagerDelegate
 extension AssetsPhotoViewController: AssetsManagerDelegate {
     
-    public func assetsManagerFetched(manager: AssetsManager) {}
+    public func assetsManagerFetched() {}
     
-    public func assetsManager(manager: AssetsManager, authorizationStatusChanged oldStatus: PHAuthorizationStatus, newStatus: PHAuthorizationStatus) {
+    public func assetsManager(authorizationStatusChanged oldStatus: PHAuthorizationStatus, newStatus: PHAuthorizationStatus) {
         if #available(iOS 14, *) {
             if newStatus == .limited {
                 updateNoPermissionView()
@@ -41,33 +41,33 @@ extension AssetsPhotoViewController: AssetsManagerDelegate {
         }
     }
     
-    public func assetsManager(manager: AssetsManager, reloadedAlbumsInSection section: Int) {}
-    public func assetsManager(manager: AssetsManager, insertedAlbums albums: [PHAssetCollection], at indexPaths: [IndexPath]) {}
+    public func assetsManager(reloadedAlbumsInSection section: Int) {}
+    public func assetsManager(insertedAlbums albums: [PHAssetCollection], at indexPaths: [IndexPath]) {}
     
-    public func assetsManager(manager: AssetsManager, removedAlbums albums: [PHAssetCollection], at indexPaths: [IndexPath]) {
+    public func assetsManager(removedAlbums albums: [PHAssetCollection], at indexPaths: [IndexPath]) {
         logi("removedAlbums at indexPaths: \(indexPaths)")
-        guard let selectedAlbum = manager.selectedAlbum else {
+        guard let selectedAlbum = AssetsManager.shared.selectedAlbum else {
             logw("selected album is nil.")
             return
         }
         if albums.contains(selectedAlbum) {
-            manager.selectDefaultAlbum()
+            AssetsManager.shared.selectDefaultAlbum()
             updateNavigationStatus()
             updateFooter()
             collectionView.reloadData()
         }
     }
     
-    public func assetsManager(manager: AssetsManager, updatedAlbums albums: [PHAssetCollection], at indexPaths: [IndexPath]) {}
-    public func assetsManager(manager: AssetsManager, reloadedAlbum album: PHAssetCollection, at indexPath: IndexPath) {}
+    public func assetsManager(updatedAlbums albums: [PHAssetCollection], at indexPaths: [IndexPath]) {}
+    public func assetsManager(reloadedAlbum album: PHAssetCollection, at indexPath: IndexPath) {}
     
-    public func assetsManager(manager: AssetsManager, insertedAssets assets: [PHAsset], at indexPaths: [IndexPath]) {
+    public func assetsManager(insertedAssets assets: [PHAsset], at indexPaths: [IndexPath]) {
         logi("insertedAssets at: \(indexPaths)")
         collectionView.insertItems(at: indexPaths)
         updateFooter()
     }
     
-    public func assetsManager(manager: AssetsManager, removedAssets assets: [PHAsset], at indexPaths: [IndexPath]) {
+    public func assetsManager(removedAssets assets: [PHAsset], at indexPaths: [IndexPath]) {
         logi("removedAssets at: \(indexPaths)")
         for removedAsset in assets {
             if let index = selectedArray.firstIndex(of: removedAsset) {
@@ -81,7 +81,7 @@ extension AssetsPhotoViewController: AssetsManagerDelegate {
         updateFooter()
     }
     
-    public func assetsManager(manager: AssetsManager, updatedAssets assets: [PHAsset], at indexPaths: [IndexPath]) {
+    public func assetsManager(updatedAssets assets: [PHAsset], at indexPaths: [IndexPath]) {
         logi("updatedAssets at: \(indexPaths)")
         let indexPathsToReload = collectionView.indexPathsForVisibleItems.filter { indexPaths.contains($0) }
         

--- a/AssetsPickerViewController/Classes/Picker/AssetsPickerConfig.swift
+++ b/AssetsPickerViewController/Classes/Picker/AssetsPickerConfig.swift
@@ -21,7 +21,7 @@ open class AssetsPickerConfig : NSObject {
     public var colors: AssetsPickerColors = AssetsPickerColors()
 
     /// Static appearances
-    public static var statusBarStyle: UIStatusBarStyle = .default
+    @MainActor public static var statusBarStyle: UIStatusBarStyle = .default
     public static var defaultCheckmarkColor: UIColor = UIColor(red: 0.078, green: 0.435, blue: 0.875, alpha: 1)
 
     /// Set selected album at initial load.

--- a/AssetsPickerViewController/Classes/Picker/Controller/AssetsPickerViewController.swift
+++ b/AssetsPickerViewController/Classes/Picker/Controller/AssetsPickerViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import Photos
 
 // MARK: - AssetsPickerViewControllerDelegate
-@objc public protocol AssetsPickerViewControllerDelegate: class {
+@objc public protocol AssetsPickerViewControllerDelegate: AnyObject {
     @objc optional func assetsPickerDidCancel(controller: AssetsPickerViewController)
     @objc optional func assetsPickerCannotAccessPhotoLibrary(controller: AssetsPickerViewController)
     func assetsPicker(controller: AssetsPickerViewController, selected assets: [PHAsset])

--- a/AssetsPickerViewController/Classes/Picker/LogConfig.swift
+++ b/AssetsPickerViewController/Classes/Picker/LogConfig.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@MainActor
 class LogConfig {
     static var isFetchLogEnabled = true
     static var isCellLogEnabled = false


### PR DESCRIPTION
- Remove unused manager variable sent as parameter for delegate methods
- Set functions to run on main actor: synchronizeAlbums and synchronizeAssets, when the observer fires `photoLibraryDidChange` these two functions are run in a Main actor task.
- Set delegate to run on main actor as it is used for ViewControllers

TODO: remove closure warnings in an upcoming PR